### PR TITLE
build: use whiskers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,47 +12,31 @@
 </p>
 
 <p align="center">
-	<img src="https://raw.githubusercontent.com/catppuccin/tofi/main/assets/preview.webp"/>
+	<img src="assets/preview.webp"/>
 </p>
 
 ## Previews
 
 <details>
 <summary>🌻 Latte</summary>
-<img src="https://raw.githubusercontent.com/catppuccin/tofi/main/assets/latte.webp"/>
+<img src="assets/latte.webp"/>
 </details>
 <details>
 <summary>🪴 Frappé</summary>
-<img src="https://raw.githubusercontent.com/catppuccin/tofi/main/assets/frappe.webp"/>
+<img src="assets/frappe.webp"/>
 </details>
 <details>
 <summary>🌺 Macchiato</summary>
-<img src="https://raw.githubusercontent.com/catppuccin/tofi/main/assets/macchiato.webp"/>
+<img src="assets/macchiato.webp"/>
 </details>
 <details>
 <summary>🌿 Mocha</summary>
-<img src="https://raw.githubusercontent.com/catppuccin/tofi/main/assets/mocha.webp"/>
+<img src="assets/mocha.webp"/>
 </details>
 
 ## Usage
 
-1. Copy the desired theme into your tofi config file (`~/.config/tofi/config`)
-- latte
-```sh
-curl https://raw.githubusercontent.com/catppuccin/tofi/main/catppuccin-latte >> ~/.config/tofi/config
-```
-- frappe
-```sh
-curl https://raw.githubusercontent.com/catppuccin/tofi/main/catppuccin-frappe >> ~/.config/tofi/config
-```
-- macchiato
-```sh
-curl https://raw.githubusercontent.com/catppuccin/tofi/main/catppuccin-macchiato >> ~/.config/tofi/config
-```
-- mocha
-```sh
-curl https://raw.githubusercontent.com/catppuccin/tofi/main/catppuccin-mocha >> ~/.config/tofi/config
-```
+1. Copy the contents of the flavor of your choice from [`themes/`](./themes/) into your Tofi configuration file (`~/.config/tofi/config`).
 
 ## 💝 Thanks to
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers tofi.tera

--- a/themes/catppuccin-frappe
+++ b/themes/catppuccin-frappe
@@ -1,4 +1,4 @@
-# frappe
+# Catppuccin Frappé
 text-color = #c6d0f5
 prompt-color = #e78284
 selection-color = #e5c890

--- a/themes/catppuccin-latte
+++ b/themes/catppuccin-latte
@@ -1,4 +1,4 @@
-# latte
+# Catppuccin Latte
 text-color = #4c4f69
 prompt-color = #d20f39
 selection-color = #df8e1d

--- a/themes/catppuccin-macchiato
+++ b/themes/catppuccin-macchiato
@@ -1,4 +1,4 @@
-# macchiato
+# Catppuccin Macchiato
 text-color = #cad3f5
 prompt-color = #ed8796
 selection-color = #eed49f

--- a/themes/catppuccin-mocha
+++ b/themes/catppuccin-mocha
@@ -1,4 +1,4 @@
-# mocha
+# Catppuccin Mocha
 text-color = #cdd6f4
 prompt-color = #f38ba8
 selection-color = #f9e2af

--- a/tofi.tera
+++ b/tofi.tera
@@ -1,0 +1,15 @@
+---
+whiskers:
+  version: 2.1.0
+  matrix:
+    - flavor
+  filename: "themes/catppuccin-{{ flavor.identifier }}"
+---
+
+{%- set palette = flavor.colors -%}
+
+# Catppuccin {{ flavor.name }}
+text-color = #{{ palette.text.hex }}
+prompt-color = #{{ palette.red.hex }}
+selection-color = #{{ palette.yellow.hex }}
+background-color = #{{ palette.base.hex }}


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the theme files directly, edit the `tofi.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed. I've also simplified the usage instructions.